### PR TITLE
ISDK-2635, ISDK-2647, ISDK-2661: Status updates after testing with the iOS 13.0 GM.

### DIFF
--- a/iOS-13-Migration-Guide.md
+++ b/iOS-13-Migration-Guide.md
@@ -48,14 +48,45 @@ At the moment, Twilio Video does not support Metal on the iOS 13.0 or iPadOS 13.
 
 6. **UIScene & UIApplication Lifecycle**
 
-iOS 13 introduces new [UIScene](https://developer.apple.com/documentation/uikit/uiscene) APIs to manage multiple instances of your app's UI, and handle lifecycle events. Twilio Video has several classes that register for UIApplication notifications and continue to do so on iOS 13:
+iOS 13 introduces new [UIScene](https://developer.apple.com/documentation/uikit/uiscene) APIs to manage multiple instances of your app's UI, and handle UI lifecycle events. Twilio Video has several classes that register for UIApplication notifications and continue to do so on iOS 13:
 
 - TVIVideoView: To render with the GPU only while the application is active.
 - TVICameraSource: To apply orientation tags to video frames.
 - TVICameraCapturer: To apply orientation tags to video frames (2.x).
 - TVIRoom: For connection management (2.x).
 
-**Status:** We are currently investigating the impact of UIScene, and compatibility with Twilio Video classes.
+**Status:** More evaluation of single and multi-window scenes is needed.
+
+We have conducted initial tests on iOS 13.0 with single window scenes using internal and public apps. The UIApplication notifications needed by Video classes are still fired in this environment:
+
+* UIApplicationDidBecomeActiveNotification
+* UIApplicationWillChangeStatusBarOrientationNotification
+* UIApplicationWillEnterForegroundNotification
+* UIApplicationWillResignActiveNotification
+
+The following .plist manifest was used for testing:
+
+```
+<key>UIApplicationSceneManifest</key>
+<dict>
+	<key>UIApplicationSupportsMultipleScenes</key>
+	<false/>
+	<key>UISceneConfigurations</key>
+	<dict>
+		<key>UIWindowSceneSessionRoleApplication</key>
+		<array>
+			<dict>
+				<key>UISceneConfigurationName</key>
+				<string>Default Configuration</string>
+				<key>UISceneDelegateClassName</key>
+				<string>YourApp.SceneDelegate</string>
+				<key>UISceneStoryboardFile</key>
+				<string>Main</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+```
 
 7. **SwiftUI**
 

--- a/iOS-13-Migration-Guide.md
+++ b/iOS-13-Migration-Guide.md
@@ -4,7 +4,7 @@ The guide explains how to prepare your Twilio Video apps for compatibility with 
 
 ## Supported SDKs
 
-We recommend that you use the latest patch releases of our SDKs. At this time, we have verified our [2.10.1](https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-2x#2101-august-16-2019), and [3.0.0-beta4](https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-3x#300-beta4-september-6-2019) SDKs for compatibility with iOS 13.0-beta8 and 13.1-beta2.
+We recommend that you use the latest patch releases of our SDKs. At this time, we have verified our [2.10.1](https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-2x#2101-august-16-2019), and [3.0.0-beta4](https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-3x#300-beta4-september-6-2019) SDKs for compatibility with iOS 13.0 and 13.1-beta2.
 
 ## Known Issues
 
@@ -16,7 +16,7 @@ We are tracking several issues related to both the Video SDK itself and the [exa
 
 Twilio Video does not support Catalyst applications at this time. If you are interested in this feature please let us know in [#49](https://github.com/twilio/twilio-video-ios/issues/49).
 
-2. **TVICameraSource - Background Task Completion Errors**
+2. **TVICameraSource - Background task completion errors**
 
 When `TVICameraSource` starts capturing it begins a background task to ensure that the video pipeline is flushed in the case of an interruption. In iOS 13.0, ending background tasks might send spurious logs to the console:
 
@@ -26,13 +26,13 @@ When `TVICameraSource` starts capturing it begins a background task to ensure th
 > 
 > 2019-09-03 13:44:21.979 VideoCallKitQuickStart[983:48546] Can't end BackgroundTask: no background task exists with identifier 3 (0x3), or it may have already been ended. Break in UIApplicationEndBackgroundTaskError() to debug.
 
-**Status:** We have given feedback to Apple, and hope that this issue can be resolved during the iOS 13 release cycle.
+**Status:** This issue is reproducible on iOS 13.0. We have given feedback to Apple, and hope that this issue can be resolved during the iOS 13 release cycle.
 
-3. **TVICameraSource - Distorted video after device usage interruption**
+3. **TVICameraSource, TVICameraCapturer - Distorted video after being interrupted by an AVCaptureSession**
 
 See issue [#53](https://github.com/twilio/twilio-video-ios/issues/53). 
 
-**Status:** We are still investigating this report and may issue patch releases of our SDK to address it.
+**Status:** This bug is reproducible on iOS 13.0. We are actively investigating a fix for our 2.x and 3.0 SDKs.
 
 4. **TVIVideoView - OpenGL ES crashes on iOS Simulator**
 
@@ -42,18 +42,18 @@ The SDK will crash when rendering decoded H.264 video, or any other frames in th
 
 5. **TVIVideoView - Metal on the iOS Simulator**
 
-At the moment, Twilio Video does not support Metal on the iOS 13.0 simulator.
+At the moment, Twilio Video does not support Metal on the iOS 13.0 or iPadOS 13.0 simulators.
 
 **Status:** We will provide an update once iOS 13.0 and macOS 10.15 are released.
 
 6. **UIScene & UIApplication Lifecycle**
 
-iOS 13 introduces new UIScene APIs to better manage navigation hierarchy and lifecycle events. Twilio Video has several classes that register for UIApplication lifecycle notifications, and continue to do so in iOS 13:
+iOS 13 introduces new [UIScene](https://developer.apple.com/documentation/uikit/uiscene) APIs to manage multiple instances of your app's UI, and handle lifecycle events. Twilio Video has several classes that register for UIApplication notifications and continue to do so on iOS 13:
 
-- TVIVideoView
-- TVICameraSource
-- TVICameraCapturer (2.x only)
-- TVIRoom (2.x only)
+- TVIVideoView: To render with the GPU only while the application is active.
+- TVICameraSource: To apply orientation tags to video frames.
+- TVICameraCapturer: To apply orientation tags to video frames (2.x).
+- TVIRoom: For connection management (2.x).
 
 **Status:** We are currently investigating the impact of UIScene, and compatibility with Twilio Video classes.
 
@@ -65,7 +65,7 @@ iOS 13 introduces new UIScene APIs to better manage navigation hierarchy and lif
 
 iPadOS 13.0 will be released on September 30th and offers a brand new multi-tasking user interface.
 
-**Status:** We are still evaluating compatibility with iPadOS 13 and expect to provide an update soon.
+**Status:** We are still evaluating compatibility with iPadOS 13 and will provide an update soon.
 
 ### Sample Code
 

--- a/iOS-13-Migration-Guide.md
+++ b/iOS-13-Migration-Guide.md
@@ -36,7 +36,7 @@ See issue [#53](https://github.com/twilio/twilio-video-ios/issues/53).
 
 4. **TVIVideoView - OpenGL ES crashes on iOS Simulator**
 
-The SDK will crash when rendering decoded H.264 video, or any other frames in the `TVIPixelFormatYUV420BiPlanarVideoRange` or `TVIPixelFormatYUV420BiPlanarFullRange` formats when using the iOS 13.0 simulator.
+The SDK will crash when rendering decoded H.264 video, or any other frames in the `TVIPixelFormatYUV420BiPlanarVideoRange` or `TVIPixelFormatYUV420BiPlanarFullRange` formats when using Xcode 11.0 and an iOS 13.0 simulator.
 
 **Resolution:** Update Twilio Video to [3.0.0-beta4](https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-3x#300-beta4-september-6-2019), or 2.10.2 (coming soon). Use an older simulator model for testing if your deployment target is earlier than 13.0.
 


### PR DESCRIPTION
* Provide updates on bugs that are confirmed with our current SDKs
* Add initial testing results to the UIScene section, and how Twilio uses UIApplication APIs
* Note: Since I haven't been able to install ReplayKitExample with Xcode 11, and iOS 13.0 GM, I have left in some references to bugs that are confirmed on iOS 13.0-beta8.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
