### PR TITLE
Update Cocoapods snippet for iOS 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ source 'https://github.com/CocoaPods/Specs'
 platform :ios, '11.0'
 
 target 'TARGET_NAME' do
-    pod 'TwilioVideo', '~> 4.0'
+    pod 'TwilioVideo', '~> 4.1'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We support integration using CocoaPods as well. You can add Programmable Video t
 ```
 source 'https://github.com/CocoaPods/Specs'
 
-platform :ios, '12.0'
+platform :ios, '11.0'
 
 target 'TARGET_NAME' do
     pod 'TwilioVideo', '~> 4.0'


### PR DESCRIPTION
The `4.1.0` brings back iOS 11 support. Updated `README.md` to reflect this.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
