### PR TITLE
Add license info to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ Please file any issues you find here on Github.
 Please ensure that you are not sharing any [Personally Identifiable Information(PII)](https://www.twilio.com/docs/glossary/what-is-personally-identifiable-information-pii) or sensitive account information (API keys, credentials, etc.) when reporting an issue.
 
 For general inquiries related to the Video SDK you can file a [support ticket](https://support.twilio.com/hc/en-us/requests/new).
+
+
+## License
+
+Twilio Programmable Video for iOS is distributed under [TWILIO-TOS](https://www.twilio.com/legal/tos).


### PR DESCRIPTION
Issue #186 was opened requesting that we document the license that the Programable Video iOS SDK is released under. Twilio Programmable Video iOS SDK is distributed under [TWILIO TOS](https://www.twilio.com/legal/tos). I will add a link to terms into the readme file.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.


CC @bobiechen-twilio We should add the same for Voice iOS as well.